### PR TITLE
:rocket: Update makefile to static link with zstd

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -17,7 +17,7 @@ TOOL_NAME = $(shell basename $(abspath ./))
 TOOL_BPF_OBJ = $(abspath $(LIBBPF_TOOLS_OUTPUT)/$(TOOL_NAME).bpf.o)
 
 CGO_CFLAGS_STATIC = "-I$(abspath $(LIBBPF_TOOLS_OUTPUT))"
-CGO_LDFLAGS_STATIC = "-lelf -lz $(LIBBPF_OBJ)"
+CGO_LDFLAGS_STATIC = "-lelf -lz -lzstd $(LIBBPF_OBJ)"
 CGO_EXTLDFLAGS_STATIC = '-w -extldflags "-static"'
 
 .PHONY: $(TOOL_NAME)


### PR DESCRIPTION
In some circumstance, the libelf will depend on zstd, if we don't static link with zstd, some error would be raised during the compile, like below

```text
/usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.1.1/../../../../lib64/libelf.a(elf_compress.o): in function `__libelf_compress':
(.text+0x103): undefined reference to `ZSTD_createCCtx'
/usr/bin/ld: (.text+0x286): undefined reference to `ZSTD_compressStream2'
/usr/bin/ld: (.text+0x292): undefined reference to `ZSTD_isError'
/usr/bin/ld: (.text+0x2be): undefined reference to `ZSTD_freeCCtx'
/usr/bin/ld: (.text+0x542): undefined reference to `ZSTD_freeCCtx'
/usr/bin/ld: (.text+0x68a): undefined reference to `ZSTD_freeCCtx'
/usr/bin/ld: (.text+0x759): undefined reference to `ZSTD_freeCCtx'
/usr/bin/ld: (.text+0x7b5): undefined reference to `ZSTD_freeCCtx'
/usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.1.1/../../../../lib64/libelf.a(elf_compress.o):(.text+0x81d): more undefined references to `ZSTD_freeCCtx' follow
/usr/bin/ld: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.1.1/../../../../lib64/libelf.a(elf_compress.o): in function `__libelf_decompress':
(.text+0x9f5): undefined reference to `ZSTD_decompress'
```

FYI https://bugs.archlinux.org/task/78526